### PR TITLE
Compatibility for 0.7/1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 deps/deps.jl
 deps/*/
+deps/build.log

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Julia wrapper for FTD2XX driver. For reference see the [D2XX Programmer's Guide]
 The below is a demonstration for a port which echos what it received.
 
 ```Julia
-julia> using LibFTD2XX
+julia> using Compat, LibFTD2XX
 
 julia> devs = createdeviceinfolist() # find out how many devices there are
 4
@@ -41,7 +41,7 @@ julia> nb_available(handle)
 julia> String(read(handle, 5))
 "Hello"
 
-julia> write(handle, Vector{UInt8}("world!"))
+julia> write(handle, codeunits("world!"))
 6
 
 julia> String(readavailable(handle))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Julia wrapper for FTD2XX driver. For reference see the [D2XX Programmer's Guide]
 The below is a demonstration for a port which echos what it received.
 
 ```Julia
-julia> using Compat, LibFTD2XX
+julia> using LibFTD2XX
 
 julia> devs = createdeviceinfolist() # find out how many devices there are
 4
@@ -41,7 +41,7 @@ julia> nb_available(handle)
 julia> String(read(handle, 5))
 "Hello"
 
-julia> write(handle, codeunits("world!"))
+julia> write(handle, Vector{UInt8}("world!"))
 6
 
 julia> String(readavailable(handle))

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 BinDeps
+Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,7 @@
 # LibFTD2XX.jl
 
+using Compat
+using Compat.Libdl
 using BinDeps
 
 Sys.WORD_SIZE != 64 && error("Build script configured only for x64")

--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -109,7 +109,7 @@ function createdeviceinfolist()
 end
 
 function getdeviceinfolist(numdevs)
-  @compat list  = Vector{FT_DEVICE_LIST_INFO_NODE}(undef, numdevs)
+  list =  @compat Vector{FT_DEVICE_LIST_INFO_NODE}(undef, numdevs)
   elnum = Ref{DWORD}(0)
   status = ccall(cfunc[:FT_GetDeviceInfoList], cdecl, FT_STATUS, 
                  (Ref{FT_DEVICE_LIST_INFO_NODE}, Ref{DWORD}),

--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -2,6 +2,9 @@
 
 module LibFTD2XX
 
+using Compat
+using Compat.Libdl
+
 export FT_HANDLE, createdeviceinfolist, getdeviceinfolist, listdevices, ftopen, 
        close, baudrate, status, FTOpenBy, OPEN_BY_SERIAL_NUMBER,
        OPEN_BY_DESCRIPTION, OPEN_BY_LOCATION
@@ -17,8 +20,8 @@ else
   error("LibFTD2XX not properly installed. Please run Pkg.build(\"LibFTD2XX\") then restart Julia.")
 end
 
-const lib = Ref{Ptr{Void}}(0)
-const cfunc = Dict{Symbol, Ptr{Void}}()
+const lib = Ref{Ptr{Cvoid}}(0)
+const cfunc = Dict{Symbol, Ptr{Cvoid}}()
 
 const cfuncn = [
   :FT_CreateDeviceInfoList
@@ -49,11 +52,11 @@ struct FT_DEVICE_LIST_INFO_NODE
   locid::DWORD
   serialnumber::NTuple{16, Cchar}
   description::NTuple{64, Cchar}
-  fthandle::Ptr{Void}
+  fthandle::Ptr{Cvoid}
 end
 
 mutable struct FT_HANDLE<:IO 
-  p::Ptr{Void} 
+  p::Ptr{Cvoid} 
 end
 
 function FT_HANDLE()
@@ -73,7 +76,7 @@ end
 function listdevices(arg1, arg2, flags)
   cfunc = Libdl.dlsym(lib[], "FT_ListDevices")
   flagsarg = DWORD(flags)
-  status = ccall(cfunc, cdecl, FT_STATUS, (Ptr{Void}, Ptr{Void}, DWORD),
+  status = ccall(cfunc, cdecl, FT_STATUS, (Ptr{Cvoid}, Ptr{Cvoid}, DWORD),
                                            arg1,      arg1,      flagsarg)
   FT_STATUS_ENUM(status) == FT_OK || throw(FT_STATUS_ENUM(status))
   arg1, arg2

--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -61,7 +61,7 @@ end
 
 function FT_HANDLE()
   handle = FT_HANDLE(C_NULL)
-  finalizer(handle, destroy!)
+  @compat finalizer(destroy!, handle)
   handle
 end
 
@@ -90,7 +90,7 @@ end
 
 function Base.String(input::NTuple{N, Cchar} where N)
   if any(input .== 0)
-    endidx = find(input .== 0)[1]-1
+    @compat endidx = findall(input .== 0)[1]-1
   elseif all(input .> 0)
     endidx = length(input)
   else
@@ -109,7 +109,7 @@ function createdeviceinfolist()
 end
 
 function getdeviceinfolist(numdevs)
-  list  = Vector{FT_DEVICE_LIST_INFO_NODE}(numdevs)
+  @compat list  = Vector{FT_DEVICE_LIST_INFO_NODE}(undef, numdevs)
   elnum = Ref{DWORD}(0)
   status = ccall(cfunc[:FT_GetDeviceInfoList], cdecl, FT_STATUS, 
                  (Ref{FT_DEVICE_LIST_INFO_NODE}, Ref{DWORD}),


### PR DESCRIPTION
Uses Compat to retain backwards compatibility with 0.6.