### PR TITLE
Add FT_SetDataCharacteristics wrapper and remove readavailable depwarning

### DIFF
--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -6,8 +6,7 @@ using Compat
 using Compat.Libdl
 
 export FT_HANDLE, createdeviceinfolist, getdeviceinfolist, listdevices, ftopen, 
-       close, baudrate, status, FTOpenBy, OPEN_BY_SERIAL_NUMBER,
-       OPEN_BY_DESCRIPTION, OPEN_BY_LOCATION
+       close, baudrate, datacharacteristics, status
 
 include("wrapper.jl")
 
@@ -31,6 +30,7 @@ const cfuncn = [
   :FT_Read
   :FT_Write
   :FT_SetBaudRate
+  :FT_SetDataCharacteristics
   :FT_GetModemStatus
   :FT_GetQueueStatus
   :FT_OpenEx
@@ -167,7 +167,15 @@ end
 function baudrate(handle::FT_HANDLE, baud)
   status = ccall(cfunc[:FT_SetBaudRate], cdecl, FT_STATUS, 
                  (FT_HANDLE, DWORD),
-                  handle,    DWORD(baud))
+                  handle,    baud)
+  FT_STATUS_ENUM(status) == FT_OK || throw(FT_STATUS_ENUM(status))
+  return
+end
+
+function datacharacteristics(handle::FT_HANDLE; wordlength::FTWordLength = BITS_8, stopbits::FTStopBits = STOP_BITS_1, parity::FTParity = PARITY_NONE)
+  status = ccall(cfunc[:FT_SetDataCharacteristics], cdecl, FT_STATUS, 
+                 (FT_HANDLE, UCHAR,      UCHAR,    UCHAR),
+                  handle,    wordlength, stopbits, parity)
   FT_STATUS_ENUM(status) == FT_OK || throw(FT_STATUS_ENUM(status))
   return
 end

--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -213,7 +213,7 @@ end
 Base.eof(handle::FT_HANDLE) = (nb_available(handle) == 0)
 
 function Base.readavailable(handle::FT_HANDLE)
-  b = Vector{UInt8}(nb_available(handle))
+  @compat b = Vector{UInt8}(undef, nb_available(handle))
   readbytes!(handle, b)
   b
 end

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -1,9 +1,15 @@
 # LibFTD2XX.jl
 
+export FTWordLength, BITS_8, BITS_7,
+       FTStopBits, STOP_BITS_1, STOP_BITS_2,
+       FTParity, PARITY_NONE, PARITY_ODD, PARITY_EVEN, PARITY_MARK, PARITY_SPACE,
+       FTOpenBy, OPEN_BY_SERIAL_NUMBER, OPEN_BY_DESCRIPTION, OPEN_BY_LOCATION
+
 # Constants
 # 
 const DWORD     = Cuint
 const ULONG     = Culong
+const UCHAR     = Cuchar
 const FT_STATUS = ULONG
 
 # FT_OpenEx Flags
@@ -100,7 +106,22 @@ const FT_PURGE_TX = 2
   FT_OTHER_ERROR,
   FT_DEVICE_LIST_NOT_READY)
 
+@enum(
+  FTWordLength,
+  BITS_8 = FT_BITS_8,
+  BITS_7 = FT_BITS_7)
 
-  
+@enum(
+  FTStopBits,
+  STOP_BITS_1 = FT_STOP_BITS_1,
+  STOP_BITS_2 = FT_STOP_BITS_2)
+
+@enum(
+  FTParity,
+  PARITY_NONE = FT_PARITY_NONE,
+  PARITY_ODD  = FT_PARITY_ODD,
+  PARITY_EVEN = FT_PARITY_EVEN,
+  PARITY_MARK = FT_PARITY_MARK,
+  PARITY_SPACE = FT_PARITY_SPACE)
 
   


### PR DESCRIPTION
Solves a leftover compatibility issue from #10 and adds a wrapper for the `FT_SetDataCharacteristics` function needed to fully set up ports for use.