### PR TITLE
Fix version number display

### DIFF
--- a/src/LibFTD2XX.jl
+++ b/src/LibFTD2XX.jl
@@ -514,10 +514,7 @@ if Sys.iswindows()
     isopen(handle) || throw(D2XXException("Device must be open to check driver version"))
     version = FT_GetDriverVersion(handle)
     @assert (version >> 24) & 0xFF == 0x00 # 4th byte should be 0 according to docs
-    patch = version & 0xFF
-    minor = (version >> 8) & 0xFF
-    major = (version >> 16) & 0xFF
-    VersionNumber(major,minor,patch)
+    Util.versionnumber(version)
   end
 
 end # Sys.iswindows()
@@ -573,10 +570,7 @@ if Sys.iswindows()
   function libversion()
     version = FT_GetLibraryVersion()
     @assert (version >> 24) & 0xFF == 0x00 # 4th byte should be 0 according to docs
-    patch = version & 0xFF
-    minor = (version >> 8) & 0xFF
-    major = (version >> 16) & 0xFF
-    VersionNumber(major,minor,patch)
+    Util.versionnumber(version)
   end
 
 end # Sys.iswindows()

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,7 +6,7 @@
 
 module Util
 
-export ntuple2string
+export ntuple2string, versionnumber
 
 
 """
@@ -34,6 +34,22 @@ function ntuple2string(input::NTuple{N, Cchar}) where N
     throw(ArgumentError("No terminator or negative values!"))
   end
   String(UInt8.([char for char in input[1:endidx]]))
+end
+
+function versionnumber(hex)
+  hex <= 0x999999 || throw(DomainError("Input must be less than 0x999999"))
+  patchhex = UInt8( (hex & 0x0000FF) >> 0 )
+  patchhex <= 0x99 || throw(DomainError("Patch field must be less than or equal to 0x99"))
+  minorhex = UInt8( (hex & 0x00FF00) >> 8 )
+  minorhex <= 0x99 || throw(DomainError("Minor field must be less than or equal to 0x99"))
+  majorhex = UInt8( (hex & 0xFF0000) >> 16 )
+  majorhex <= 0x99 || throw(DomainError("Minor field must be less than or equal to 0x99"))
+  
+  patchdec = 10(patchhex >> 4) + (patchhex & 0x0F)
+  minordec = 10(minorhex >> 4) + (minorhex & 0x0F)
+  majordec = 10(majorhex >> 4) + (majorhex & 0x0F)
+  
+  VersionNumber(majordec,minordec,patchdec)
 end
 
 end # module Util

--- a/test/util.jl
+++ b/test/util.jl
@@ -10,6 +10,14 @@ using LibFTD2XX.Util
 @testset "util" begin
   @test "hello" == ntuple2string(Cchar.(('h','e','l','l','o')))
   @test "hello" == ntuple2string(Cchar.(('h','e','l','l','o','\0','x')))
+
+  @test v"0.0.0" == versionnumber(0)
+  @test v"99.99.99" == versionnumber(0x00999999)
+  @test v"2.12.28" == versionnumber(0x00021228)
+  @test_throws DomainError versionnumber(0x00999999 + 1)
+  @test_throws DomainError versionnumber(0x000000AA)
+  @test_throws DomainError versionnumber(0x0000AA00)
+  @test_throws DomainError versionnumber(0x00AA0000)
 end
 
 end


### PR DESCRIPTION
Corrects the display of version numbers given buy the `libversion` and `driverversion` functions. 

It turns out that the version number representation displays decimal numbers as though they are hexadecimal. From the documentation for `FT_GetLibraryVersion` in the [D2XX Programmers Guide](https://www.ftdichip.com/Support/Documents/ProgramGuides/D2XX_Programmer's_Guide(FT_000071).pdf):

> A version number consists of major, minor and build version numbers contained in a 4-byte field
> (unsigned long). Byte0 (least significant) holds the build version, Byte1 holds the minor version, and
> Byte2 holds the major version. Byte3 is currently set to zero.
> 
> For example, D2XX DLL version "3.01.15" is represented as 0x00030115. Note that this function does
> not take a handle, and so it can be called without opening a device.